### PR TITLE
Validate span kind and add test coverage

### DIFF
--- a/signalbuilder/trace.go
+++ b/signalbuilder/trace.go
@@ -107,7 +107,11 @@ func (tb *TracesBuilder) Add(rt *ResourceTraces) error {
 				}
 			}
 
-			span.SetKind(ptrace.SpanKind(sp.Kind))
+			kind := ptrace.SpanKind(sp.Kind)
+			if kind.String() == "" {
+				return fmt.Errorf("invalid span kind %d", sp.Kind)
+			}
+			span.SetKind(kind)
 			span.SetStartTimestamp(pcommon.Timestamp(sp.StartTimestamp))
 			span.SetEndTimestamp(pcommon.Timestamp(sp.EndTimestamp))
 

--- a/signalbuilder/trace_structured_test.go
+++ b/signalbuilder/trace_structured_test.go
@@ -380,3 +380,22 @@ func TestInvalidTraceSpanIDsInTraces(t *testing.T) {
 	err = builder.Add(rt3)
 	assert.NoError(t, err)
 }
+
+func TestInvalidSpanKindInTraces(t *testing.T) {
+	builder := NewTracesBuilder()
+	rt := &ResourceTraces{
+		ScopeTraces: []ScopeTraces{
+			{
+				Spans: []Span{
+					{
+						Name: "Test span",
+						Kind: 99,
+					},
+				},
+			},
+		},
+	}
+	err := builder.Add(rt)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid span kind")
+}


### PR DESCRIPTION
## Summary
- validate span kind values before setting them on spans
- add test ensuring invalid span kinds return errors

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ad195461c483218404ba3a7b6d0076