### PR TITLE
feat(telemetry): add WithSecondaryExporter for dual-destination export

### DIFF
--- a/pkg/telemetry/options.go
+++ b/pkg/telemetry/options.go
@@ -27,6 +27,14 @@ type setupConfig struct {
 	httpClient     *http.Client
 	headerProvider func() map[string]string
 	resource       *resource.Resource
+	secondary      *secondaryExporter
+}
+
+// secondaryExporter describes an additional OTLP/HTTP destination that receives
+// the same telemetry as the primary exporter.
+type secondaryExporter struct {
+	endpoint string
+	headers  map[string]string
 }
 
 // WithHTTPClient sets a custom HTTP client for all OTLP exporters.
@@ -50,6 +58,20 @@ func WithResource(r *resource.Resource) Option {
 func WithHeaderProvider(provider func() map[string]string) Option {
 	return func(c *setupConfig) {
 		c.headerProvider = provider
+	}
+}
+
+// WithSecondaryExporter adds a second OTLP/HTTP destination that receives the
+// same traces, metrics, and logs as the primary exporter, with the same
+// resource. The endpoint must be a full URL (e.g. https://host:4318); its
+// scheme selects TLS. headers are static, set on every request to this
+// destination. An empty endpoint is a no-op.
+func WithSecondaryExporter(endpoint string, headers map[string]string) Option {
+	return func(c *setupConfig) {
+		if endpoint == "" {
+			return
+		}
+		c.secondary = &secondaryExporter{endpoint: endpoint, headers: headers}
 	}
 }
 

--- a/pkg/telemetry/otel_setup.go
+++ b/pkg/telemetry/otel_setup.go
@@ -93,7 +93,7 @@ func SetupOTelSDK(ctx context.Context, opts ...Option) (shutdown func(context.Co
 	otel.SetTextMapPropagator(prop)
 
 	// Set up trace provider.
-	tracerProvider, err := newTracerProvider(ctx, insecure, httpClient, res)
+	tracerProvider, err := newTracerProvider(ctx, insecure, httpClient, res, cfg.secondary)
 	if err != nil {
 		handleErr(err)
 		return
@@ -102,7 +102,7 @@ func SetupOTelSDK(ctx context.Context, opts ...Option) (shutdown func(context.Co
 	otel.SetTracerProvider(tracerProvider)
 
 	// Set up meter provider.
-	meterProvider, err := newMeterProvider(ctx, insecure, httpClient, res)
+	meterProvider, err := newMeterProvider(ctx, insecure, httpClient, res, cfg.secondary)
 	if err != nil {
 		handleErr(err)
 		return
@@ -111,7 +111,7 @@ func SetupOTelSDK(ctx context.Context, opts ...Option) (shutdown func(context.Co
 	otel.SetMeterProvider(meterProvider)
 
 	// Set up logger provider.
-	loggerProvider, err := newLoggerProvider(ctx, insecure, httpClient, res)
+	loggerProvider, err := newLoggerProvider(ctx, insecure, httpClient, res, cfg.secondary)
 	if err != nil {
 		handleErr(err)
 		return
@@ -129,7 +129,7 @@ func newPropagator() propagation.TextMapPropagator {
 	)
 }
 
-func newTracerProvider(ctx context.Context, insecure bool, httpClient *http.Client, res *resource.Resource) (*trace.TracerProvider, error) {
+func newTracerProvider(ctx context.Context, insecure bool, httpClient *http.Client, res *resource.Resource, secondary *secondaryExporter) (*trace.TracerProvider, error) {
 	opts := []otlptracehttp.Option{}
 	if insecure {
 		opts = append(opts, otlptracehttp.WithInsecure())
@@ -143,13 +143,24 @@ func newTracerProvider(ctx context.Context, insecure bool, httpClient *http.Clie
 	}
 
 	tpOpts := []trace.TracerProviderOption{trace.WithBatcher(traceExporter)}
+	if secondary != nil {
+		secOpts := []otlptracehttp.Option{otlptracehttp.WithEndpointURL(secondary.endpoint)}
+		if len(secondary.headers) > 0 {
+			secOpts = append(secOpts, otlptracehttp.WithHeaders(secondary.headers))
+		}
+		secExporter, err := otlptracehttp.New(ctx, secOpts...)
+		if err != nil {
+			return nil, err
+		}
+		tpOpts = append(tpOpts, trace.WithBatcher(secExporter))
+	}
 	if res != nil {
 		tpOpts = append(tpOpts, trace.WithResource(res))
 	}
 	return trace.NewTracerProvider(tpOpts...), nil
 }
 
-func newMeterProvider(ctx context.Context, insecure bool, httpClient *http.Client, res *resource.Resource) (*metric.MeterProvider, error) {
+func newMeterProvider(ctx context.Context, insecure bool, httpClient *http.Client, res *resource.Resource, secondary *secondaryExporter) (*metric.MeterProvider, error) {
 	opts := []otlpmetrichttp.Option{}
 	if insecure {
 		opts = append(opts, otlpmetrichttp.WithInsecure())
@@ -163,13 +174,24 @@ func newMeterProvider(ctx context.Context, insecure bool, httpClient *http.Clien
 	}
 
 	mpOpts := []metric.Option{metric.WithReader(metric.NewPeriodicReader(metricExporter))}
+	if secondary != nil {
+		secOpts := []otlpmetrichttp.Option{otlpmetrichttp.WithEndpointURL(secondary.endpoint)}
+		if len(secondary.headers) > 0 {
+			secOpts = append(secOpts, otlpmetrichttp.WithHeaders(secondary.headers))
+		}
+		secExporter, err := otlpmetrichttp.New(ctx, secOpts...)
+		if err != nil {
+			return nil, err
+		}
+		mpOpts = append(mpOpts, metric.WithReader(metric.NewPeriodicReader(secExporter)))
+	}
 	if res != nil {
 		mpOpts = append(mpOpts, metric.WithResource(res))
 	}
 	return metric.NewMeterProvider(mpOpts...), nil
 }
 
-func newLoggerProvider(ctx context.Context, insecure bool, httpClient *http.Client, res *resource.Resource) (*otellog.LoggerProvider, error) {
+func newLoggerProvider(ctx context.Context, insecure bool, httpClient *http.Client, res *resource.Resource, secondary *secondaryExporter) (*otellog.LoggerProvider, error) {
 	opts := []otlploghttp.Option{}
 	if insecure {
 		opts = append(opts, otlploghttp.WithInsecure())
@@ -183,6 +205,17 @@ func newLoggerProvider(ctx context.Context, insecure bool, httpClient *http.Clie
 	}
 
 	lpOpts := []otellog.LoggerProviderOption{otellog.WithProcessor(otellog.NewBatchProcessor(logExporter))}
+	if secondary != nil {
+		secOpts := []otlploghttp.Option{otlploghttp.WithEndpointURL(secondary.endpoint)}
+		if len(secondary.headers) > 0 {
+			secOpts = append(secOpts, otlploghttp.WithHeaders(secondary.headers))
+		}
+		secExporter, err := otlploghttp.New(ctx, secOpts...)
+		if err != nil {
+			return nil, err
+		}
+		lpOpts = append(lpOpts, otellog.WithProcessor(otellog.NewBatchProcessor(secExporter)))
+	}
 	if res != nil {
 		lpOpts = append(lpOpts, otellog.WithResource(res))
 	}

--- a/pkg/telemetry/secondary_exporter_test.go
+++ b/pkg/telemetry/secondary_exporter_test.go
@@ -1,0 +1,128 @@
+// Copyright 2024-2025 CardinalHQ, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	otellogapi "go.opentelemetry.io/otel/log"
+)
+
+// otlpRecorder is an httptest server that counts inbound OTLP/HTTP POSTs and
+// returns the empty success body the exporters expect.
+func otlpRecorder(t *testing.T) (*httptest.Server, *int64) {
+	t.Helper()
+	var count int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt64(&count, 1)
+		w.Header().Set("Content-Type", "application/x-protobuf")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte{})
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &count
+}
+
+func TestWithSecondaryExporter_SetsConfig(t *testing.T) {
+	cfg := &setupConfig{}
+	WithSecondaryExporter("https://example.com:4318", map[string]string{"x": "y"})(cfg)
+	require.NotNil(t, cfg.secondary)
+	assert.Equal(t, "https://example.com:4318", cfg.secondary.endpoint)
+	assert.Equal(t, map[string]string{"x": "y"}, cfg.secondary.headers)
+}
+
+func TestWithSecondaryExporter_EmptyEndpointIsNoop(t *testing.T) {
+	cfg := &setupConfig{}
+	WithSecondaryExporter("", map[string]string{"x": "y"})(cfg)
+	assert.Nil(t, cfg.secondary)
+}
+
+func TestTracerProvider_FansOutToSecondary(t *testing.T) {
+	primary, primaryCount := otlpRecorder(t)
+	secondary, secondaryCount := otlpRecorder(t)
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", primary.URL)
+
+	ctx := context.Background()
+	tp, err := newTracerProvider(ctx, true, nil, nil, &secondaryExporter{endpoint: secondary.URL})
+	require.NoError(t, err)
+
+	_, span := tp.Tracer("test").Start(ctx, "span")
+	span.End()
+	require.NoError(t, tp.ForceFlush(ctx))
+	require.NoError(t, tp.Shutdown(ctx))
+
+	assert.Positive(t, atomic.LoadInt64(primaryCount), "primary must receive traces")
+	assert.Positive(t, atomic.LoadInt64(secondaryCount), "secondary must receive traces")
+}
+
+func TestTracerProvider_NoSecondaryOnlyPrimary(t *testing.T) {
+	primary, primaryCount := otlpRecorder(t)
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", primary.URL)
+
+	ctx := context.Background()
+	tp, err := newTracerProvider(ctx, true, nil, nil, nil)
+	require.NoError(t, err)
+
+	_, span := tp.Tracer("test").Start(ctx, "span")
+	span.End()
+	require.NoError(t, tp.ForceFlush(ctx))
+	require.NoError(t, tp.Shutdown(ctx))
+
+	assert.Positive(t, atomic.LoadInt64(primaryCount), "primary must receive traces")
+}
+
+func TestMeterProvider_FansOutToSecondary(t *testing.T) {
+	primary, primaryCount := otlpRecorder(t)
+	secondary, secondaryCount := otlpRecorder(t)
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", primary.URL)
+
+	ctx := context.Background()
+	mp, err := newMeterProvider(ctx, true, nil, nil, &secondaryExporter{endpoint: secondary.URL})
+	require.NoError(t, err)
+
+	counter, err := mp.Meter("test").Int64Counter("c")
+	require.NoError(t, err)
+	counter.Add(ctx, 1)
+	require.NoError(t, mp.ForceFlush(ctx))
+	require.NoError(t, mp.Shutdown(ctx))
+
+	assert.Positive(t, atomic.LoadInt64(primaryCount), "primary must receive metrics")
+	assert.Positive(t, atomic.LoadInt64(secondaryCount), "secondary must receive metrics")
+}
+
+func TestLoggerProvider_FansOutToSecondary(t *testing.T) {
+	primary, primaryCount := otlpRecorder(t)
+	secondary, secondaryCount := otlpRecorder(t)
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", primary.URL)
+
+	ctx := context.Background()
+	lp, err := newLoggerProvider(ctx, true, nil, nil, &secondaryExporter{endpoint: secondary.URL})
+	require.NoError(t, err)
+
+	var rec otellogapi.Record
+	rec.SetBody(otellogapi.StringValue("hello"))
+	lp.Logger("test").Emit(ctx, rec)
+	require.NoError(t, lp.ForceFlush(ctx))
+	require.NoError(t, lp.Shutdown(ctx))
+
+	assert.Positive(t, atomic.LoadInt64(primaryCount), "primary must receive logs")
+	assert.Positive(t, atomic.LoadInt64(secondaryCount), "secondary must receive logs")
+}


### PR DESCRIPTION
## What

Adds `telemetry.WithSecondaryExporter(endpoint, headers)` — an additive `SetupOTelSDK` option that registers a **second** OTLP/HTTP exporter for traces, metrics, and logs alongside the primary.

- The secondary shares the provider's resource, force-flush, and shutdown.
- Endpoint must be a full URL; its scheme (`http`/`https`) selects TLS.
- Headers are static, applied to every request to the secondary destination.
- **Primary behavior is unchanged** when no secondary is configured.

## Why

Lakerunner needs to ship its self-telemetry to both the license-configured endpoint *and* an operator-chosen destination (`LAKERUNNER_SELF_TELEMETRY_ENDPOINT`). The OTel SDK providers natively support multiple batchers/readers/processors; this exposes that as one option.

## Tests

`pkg/telemetry/secondary_exporter_test.go`: two `httptest` OTLP receivers assert fan-out across all three signals when a secondary is set, and primary-only when it isn't. Plus config-plumbing unit tests for the option. `make check` passes (race tests, license headers, lint).