### PR TITLE
fix(telemetry): secondary log exporter posts to /v1/logs

### DIFF
--- a/pkg/telemetry/otel_setup.go
+++ b/pkg/telemetry/otel_setup.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 
 	"go.opentelemetry.io/otel"
@@ -207,6 +208,15 @@ func newLoggerProvider(ctx context.Context, insecure bool, httpClient *http.Clie
 	lpOpts := []otellog.LoggerProviderOption{otellog.WithProcessor(otellog.NewBatchProcessor(logExporter))}
 	if secondary != nil {
 		secOpts := []otlploghttp.Option{otlploghttp.WithEndpointURL(secondary.endpoint)}
+		// otlploghttp's WithEndpointURL uses the URL path verbatim; a path-less
+		// endpoint resolves to "/" (404 at an OTLP collector) rather than the
+		// standard "/v1/logs". The otlptracehttp/otlpmetrichttp exporters default
+		// an empty path to /v1/{signal}, but the log exporter does not — so the
+		// secondary log sink silently 404s while metrics/traces flow. Force the
+		// standard path when the operator-supplied endpoint carries none.
+		if u, perr := url.Parse(secondary.endpoint); perr == nil && (u.Path == "" || u.Path == "/") {
+			secOpts = append(secOpts, otlploghttp.WithURLPath("/v1/logs"))
+		}
 		if len(secondary.headers) > 0 {
 			secOpts = append(secOpts, otlploghttp.WithHeaders(secondary.headers))
 		}

--- a/pkg/telemetry/secondary_exporter_test.go
+++ b/pkg/telemetry/secondary_exporter_test.go
@@ -197,3 +197,39 @@ func TestLoggerProvider_FansOutToSecondary(t *testing.T) {
 	assert.Positive(t, atomic.LoadInt64(primaryCount), "primary must receive logs")
 	assert.Positive(t, atomic.LoadInt64(secondaryCount), "secondary must receive logs")
 }
+
+// Regression: otlploghttp.WithEndpointURL uses the URL path verbatim, so a
+// path-less secondary endpoint (e.g. "http://collector:4318") resolves to "/"
+// and 404s at a real OTLP collector — unlike otlptracehttp/otlpmetrichttp,
+// which default an empty path to /v1/{signal}. newLoggerProvider must force
+// "/v1/logs" so the secondary log sink actually receives data.
+func TestLoggerProvider_SecondaryUsesV1LogsPath(t *testing.T) {
+	var mu sync.Mutex
+	var secPath string
+	primary, _ := otlpRecorder(t)
+	secondary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		mu.Lock()
+		secPath = req.URL.Path
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/x-protobuf")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte{})
+	}))
+	t.Cleanup(secondary.Close)
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", primary.URL)
+
+	ctx := context.Background()
+	// secondary.URL is scheme+host only (no path) — the exact case that 404s.
+	lp, err := newLoggerProvider(ctx, true, nil, nil, &secondaryExporter{endpoint: secondary.URL})
+	require.NoError(t, err)
+
+	var rec otellogapi.Record
+	rec.SetBody(otellogapi.StringValue("hello"))
+	lp.Logger("test").Emit(ctx, rec)
+	require.NoError(t, lp.ForceFlush(ctx))
+	require.NoError(t, lp.Shutdown(ctx))
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, "/v1/logs", secPath, "secondary log exporter must POST to /v1/logs, not the bare endpoint path")
+}


### PR DESCRIPTION
## Problem

`WithSecondaryExporter` fans self-telemetry to a second OTLP/HTTP destination. Metrics and traces arrive there; **logs 404**. Observed against a real collector:

```
otel: failed to send logs to http://<collector>:4318: 404 Not Found (body: 404 page not found)
```

## Root cause

The three secondary exporters are all built with `WithEndpointURL(secondary.endpoint)`, but the modules differ:

| Exporter | module | path-less `WithEndpointURL` → |
|---|---|---|
| traces (`otlptracehttp`) | v1.44.0 | `/v1/traces` (unconditional `cleanPath` default) |
| metrics (`otlpmetrichttp`) | v1.44.0 | `/v1/metrics` (same) |
| **logs (`otlploghttp`)** | **v0.20.0** | **`/`** |

`otlploghttp.WithEndpointURL` sets `c.path = newSetting(u.Path)` — an *explicit* empty string for a base URL. The `/v1/logs` default is only a `fallback` in `c.path.Resolve(...)`, which is skipped when the value is explicitly set, so the path stays empty → the exporter POSTs to `/`. The stable trace/metric modules apply their default unconditionally via `cleanPath`; the log module (still v0.x, stricter — `WithEndpointURL` is spec'd to use the URL as-is) does not. Bumping otlploghttp does not change this (v0.19.0 and v0.20.0 are identical here).

The **primary** log export is unaffected — it goes through `OTEL_EXPORTER_OTLP_ENDPOINT`, whose env path handling (`convPath`) does append `/v1/logs`.

## Fix

In `newLoggerProvider`, force `/v1/logs` on the secondary log exporter when the endpoint has no path:

```go
if u, perr := url.Parse(secondary.endpoint); perr == nil && (u.Path == "" || u.Path == "/") {
    secOpts = append(secOpts, otlploghttp.WithURLPath("/v1/logs"))
}
```

Trace/metric secondaries are untouched (already correct). An endpoint that *does* carry a path is respected.

## Test

`TestLoggerProvider_SecondaryUsesV1LogsPath` records the request path at a test server and asserts `/v1/logs`. The pre-existing `otlpRecorder` accepted any path, which is why the bug slipped through. Verified the test **fails without the fix** (`expected "/v1/logs", actual "/"`) and passes with it. `go build`, `go vet`, and the full `pkg/telemetry` suite are green.

https://claude.ai/code/session_01YUSQ89u33yHnnrzfn5nhik