### PR TITLE
chore: bump go to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cardinalhq/oteltools
 
-go 1.26
+go 1.26.5
 
 require (
 	github.com/DataDog/sketches-go v1.4.8

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/cardinalhq/oteltools/internal/tools
 
-go 1.26.4
+go 1.26.5
 
 tool (
 	github.com/apache/skywalking-eyes/cmd/license-eye


### PR DESCRIPTION
Bumps the go directive to 1.26.5.